### PR TITLE
Add debug helpers for Clerk and Convex on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,30 @@
 "use client"
 
-import { Authenticated, Unauthenticated } from "convex/react";
-import { SignInButton, UserButton } from "@clerk/nextjs";
+import { Authenticated, Unauthenticated, useQuery } from "convex/react"; // added useQuery for convex debug test
+import { SignInButton, UserButton, useUser } from "@clerk/nextjs"; // added useUser for clerk debug test
+import { api } from "@/convex/_generated/api"; // added convex api for debug query
 
 export default function Home() {
+  const { user, isLoaded, isSignedIn } = useUser(); // added clerk state for debug output
+  const messages = useQuery(api.messages.getForCurrentUser, isSignedIn ? {} : undefined); // added convex query guarded by auth
+
+  const handleClerkTest = () => { // added handler to log clerk debug info
+    console.debug("Clerk debug", {
+      isLoaded,
+      isSignedIn,
+      userId: user?.id,
+      email: user?.primaryEmailAddress?.emailAddress,
+    });
+  };
+
+  const handleConvexTest = () => { // added handler to log convex debug info
+    console.debug("Convex debug", {
+      isSignedIn,
+      messageCount: messages?.length ?? "n/a",
+      messages,
+    });
+  };
+
   return (
     <main>
 
@@ -38,7 +59,7 @@ export default function Home() {
               </UserButton>
 
               {/* test clerk button */}
-              <button color="black" className="text-white bg-fuchsia-800 px-6 py-3 rounded-md drop-shadow-md cursor-pointer hover:bg-fuchsia-950">
+              <button color="black" className="text-white bg-fuchsia-800 px-6 py-3 rounded-md drop-shadow-md cursor-pointer hover:bg-fuchsia-950" onClick={handleClerkTest}>
                 test clerk
               </button>
             </div>
@@ -49,7 +70,7 @@ export default function Home() {
         <div className="flex justify-center min-w-1/2 drop-shadow-md bg-amber-950/20 rounded-md overflow-y-auto p-12">
 
           {/* button */}
-          <button color="black" className="text-white bg-amber-800 hover:bg-amber-950 px-6 py-3 rounded-md drop-shadow-md cursor-pointer">
+          <button color="black" className="text-white bg-amber-800 hover:bg-amber-950 px-6 py-3 rounded-md drop-shadow-md cursor-pointer" onClick={handleConvexTest}>
             test convex
           </button>
         </div>
@@ -59,11 +80,36 @@ export default function Home() {
       <section className="flex flex-row grid-cols-2 gap-3 justify-center max-w-full max-h-75 mt-12 mx-[10%] bg-neutral-800 drop-shadow-md rounded-md p-4">
 
         <div className="flex justify-start align-top min-w-1/2 drop-shadow-md bg-fuchsia-950/20 rounded-md p-12 overflow-y-auto">
-          clerk debug
+          <pre className="whitespace-pre-wrap text-xs">{/* added clerk debug output */}
+            {isLoaded
+              ? JSON.stringify(
+                  {
+                    isSignedIn,
+                    userId: user?.id ?? null,
+                    email: user?.primaryEmailAddress?.emailAddress ?? null,
+                  },
+                  null,
+                  2,
+                )
+              : "Loading Clerk state..."}
+          </pre>
         </div>
 
         <div className="flex justify-start min-w-1/2 drop-shadow-md bg-amber-950/20 rounded-md overflow-y-auto p-12">
-          convex debug
+          <pre className="whitespace-pre-wrap text-xs">{/* added convex debug output */}
+            {isSignedIn
+              ? messages
+                ? JSON.stringify(
+                    {
+                      messageCount: messages.length,
+                      messages,
+                    },
+                    null,
+                    2,
+                  )
+                : "Loading Convex data..."
+              : "Sign in to load Convex data."}
+          </pre>
         </div>
       </section>
     </main >


### PR DESCRIPTION
## Summary
- add Clerk debug state logging and output to the home page for quick verification
- query Convex messages for the signed-in user and expose a debug view with logging hooks

## Testing
- not run (environment variables not configured)


------
https://chatgpt.com/codex/tasks/task_e_68d74c3260188326abe0459bca92be6f