### PR TITLE
Rearrange debug dashboard into responsive grid

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -43,135 +43,129 @@ export default function Home() {
     : "Use the Stripe checkout controls to populate debug logs.";
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-950 py-12 text-neutral-100">
-      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-12">
-        <div className="overflow-hidden rounded-3xl border border-neutral-800/80 bg-neutral-950/70 shadow-[0_40px_120px_-60px_rgba(15,15,15,0.8)]">
-          <div className="flex flex-col gap-6 border-b border-neutral-800/80 bg-neutral-900/60 px-6 py-10 text-center sm:px-10">
-            <p className="mx-auto w-fit rounded-full border border-fuchsia-500/40 bg-fuchsia-900/20 px-3 py-1 text-[10px] uppercase tracking-[0.35em] text-fuchsia-200/80">
-              Rodeo Platform
+    <main className="min-h-screen bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-950 py-8 text-neutral-100">
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-10">
+        <header className="mb-8 grid gap-2 text-center text-sm uppercase tracking-[0.32em] text-neutral-400">
+          <span className="justify-self-center rounded-full border border-neutral-700/70 px-3 py-1 text-[10px] text-neutral-300/80">
+            Rodeo Platform
+          </span>
+          <div className="space-y-1 text-base normal-case tracking-normal text-neutral-300">
+            <h1 className="text-3xl font-semibold text-white sm:text-4xl">rodeo-kiosk</h1>
+            <p className="text-xs uppercase tracking-[0.28em] text-neutral-500 sm:text-[0.72rem]">
+              Clerk · Convex · Stripe debug deck
             </p>
-            <div className="space-y-4">
-              <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-[2.6rem]">rodeo-kiosk</h1>
-              <p className="mx-auto max-w-xl text-sm text-neutral-300 sm:text-base">
-                A consolidated console for Clerk authentication, Convex diagnostics, and Stripe checkout flows.
+          </div>
+        </header>
+
+        <section className="grid min-h-[55vh] grid-cols-1 gap-px border border-neutral-800/60 bg-neutral-800/60 text-sm lg:grid-cols-2">
+          <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-fuchsia-200">Authentication</h2>
+              <p className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">Clerk controls</p>
+              <p className="text-sm text-neutral-400">
+                Sign in with Clerk to unlock debugging utilities.
               </p>
             </div>
+            <Unauthenticated>
+              <SignInButton mode="modal">
+                <button className="inline-flex w-full items-center justify-center gap-2 border border-fuchsia-500/40 bg-fuchsia-900/30 px-4 py-2 text-sm font-semibold text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-800/40">
+                  Sign in with Clerk
+                </button>
+              </SignInButton>
+            </Unauthenticated>
+            <Authenticated>
+              <div className="grid gap-3">
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.28em] text-neutral-500">
+                  <span>Current user</span>
+                  <UserButton userProfileMode="modal" />
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <button
+                    className="inline-flex items-center justify-center border border-fuchsia-500/30 bg-fuchsia-900/30 px-4 py-2 text-sm font-medium text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-800/40"
+                    onClick={handleClerkTest}
+                  >
+                    Test Clerk
+                  </button>
+                  <button
+                    className="inline-flex items-center justify-center border border-emerald-500/30 bg-emerald-900/30 px-4 py-2 text-sm font-medium text-emerald-100 transition hover:border-emerald-300/60 hover:bg-emerald-800/40"
+                    onClick={handleAddDemoMessage}
+                  >
+                    Add demo message
+                  </button>
+                </div>
+              </div>
+            </Authenticated>
           </div>
 
-          <section className="grid gap-8 px-6 py-10 sm:px-12 lg:grid-cols-2 xl:gap-12">
-            <div className="flex flex-col gap-6 rounded-2xl border border-neutral-800/80 bg-neutral-900/40 p-6 shadow-inner shadow-black/20">
-              <div className="space-y-2">
-                <h2 className="font-semibold text-fuchsia-200">Authentication</h2>
-                <p className="text-xs uppercase tracking-widest text-neutral-500">Clerk access</p>
-                <p className="text-sm text-neutral-300">
-                  Sign in with Clerk to unlock the debugging utilities.
-                </p>
-              </div>
-              <Unauthenticated>
-                <SignInButton mode="modal">
-                  <button className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-fuchsia-500/40 bg-fuchsia-900/30 px-4 py-3 text-sm font-semibold text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-800/40">
-                    Sign in with Clerk
-                  </button>
-                </SignInButton>
-              </Unauthenticated>
-              <Authenticated>
-                <div className="grid gap-4 rounded-xl border border-fuchsia-500/20 bg-fuchsia-900/10 p-5">
-                  <div className="flex items-center justify-between gap-4">
-                    <span className="text-xs uppercase tracking-widest text-neutral-400">Current user</span>
-                    <UserButton userProfileMode="modal" />
-                  </div>
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    <button
-                      className="inline-flex items-center justify-center rounded-lg border border-fuchsia-500/30 bg-fuchsia-800/40 px-4 py-2 text-sm font-medium text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-700/50"
-                      onClick={handleClerkTest}
-                    >
-                      Test Clerk
-                    </button>
-                    <button
-                      className="inline-flex items-center justify-center rounded-lg border border-emerald-500/30 bg-emerald-800/30 px-4 py-2 text-sm font-medium text-emerald-50 transition hover:border-emerald-300/60 hover:bg-emerald-700/40"
-                      onClick={handleAddDemoMessage}
-                    >
-                      Add demo message
-                    </button>
-                  </div>
-                </div>
-              </Authenticated>
-            </div>
+          <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">
+            <header className="space-y-1">
+              <p className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">Clerk stream</p>
+              <h3 className="text-lg font-semibold text-fuchsia-200">State snapshot</h3>
+            </header>
+            <pre className="h-56 overflow-y-auto border border-fuchsia-500/20 bg-neutral-950/80 p-4 text-xs leading-relaxed text-fuchsia-100">
+              {isLoaded
+                ? JSON.stringify(
+                    {
+                      isSignedIn,
+                      userId: user?.id ?? null,
+                      email: user?.primaryEmailAddress?.emailAddress ?? null,
+                    },
+                    null,
+                    2,
+                  )
+                : "Loading Clerk state..."}
+            </pre>
+          </div>
 
-            <div className="flex flex-col gap-4 rounded-2xl border border-neutral-800/80 bg-neutral-900/30 p-6 shadow-inner shadow-black/20">
-              <header className="flex flex-col gap-1">
-                <span className="text-xs uppercase tracking-widest text-neutral-500">Clerk stream</span>
-                <h3 className="font-semibold text-fuchsia-200">State snapshot</h3>
-              </header>
-              <pre className="min-h-[200px] flex-1 overflow-y-auto rounded-xl border border-fuchsia-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-fuchsia-100">
-                {isLoaded
-                  ? JSON.stringify(
-                      {
-                        isSignedIn,
-                        userId: user?.id ?? null,
-                        email: user?.primaryEmailAddress?.emailAddress ?? null,
-                      },
-                      null,
-                      2,
-                    )
-                  : "Loading Clerk state..."}
-              </pre>
+          <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-amber-200">Convex</h2>
+              <p className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">Action triggers</p>
+              <p className="text-sm text-neutral-400">Ping Convex to confirm connectivity and data flow.</p>
             </div>
+            <button
+              className="inline-flex w-full items-center justify-center border border-amber-500/40 bg-amber-900/30 px-4 py-2 text-sm font-semibold text-amber-100 transition hover:border-amber-300/60 hover:bg-amber-800/40"
+              onClick={handleConvexTest}
+            >
+              Test Convex
+            </button>
+          </div>
 
-            <div className="flex flex-col gap-6 rounded-2xl border border-neutral-800/80 bg-neutral-900/40 p-6 shadow-inner shadow-black/20">
-              <div className="space-y-2">
-                <h2 className="font-semibold text-amber-200">Convex actions</h2>
-                <p className="text-xs uppercase tracking-widest text-neutral-500">Diagnostics</p>
-                <p className="text-sm text-neutral-300">
-                  Trigger a Convex check to confirm connectivity and observe data flow.
-                </p>
-              </div>
-              <button
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-amber-500/40 bg-amber-900/30 px-4 py-3 text-sm font-semibold text-amber-100 transition hover:border-amber-300/60 hover:bg-amber-800/40"
-                onClick={handleConvexTest}
-              >
-                Test Convex
-              </button>
-            </div>
+          <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">
+            <header className="space-y-1">
+              <p className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">Convex stream</p>
+              <h3 className="text-lg font-semibold text-amber-200">Data snapshot</h3>
+            </header>
+            <pre className="h-56 overflow-y-auto border border-amber-500/20 bg-neutral-950/80 p-4 text-xs leading-relaxed text-amber-100">
+              {(() => {
+                if (!isLoaded) return "Loading Clerk state...";
+                if (!isSignedIn) return "Sign in to load Convex data.";
+                if (messages === undefined) return "Loading Convex data...";
+                if (messages.length === 0) return "No messages yet.";
+                return JSON.stringify({ messageCount: messages.length, messages }, null, 2);
+              })()}
+            </pre>
+          </div>
 
-            <div className="flex flex-col gap-4 rounded-2xl border border-neutral-800/80 bg-neutral-900/30 p-6 shadow-inner shadow-black/20">
-              <header className="flex flex-col gap-1">
-                <span className="text-xs uppercase tracking-widest text-neutral-500">Convex stream</span>
-                <h3 className="font-semibold text-amber-200">Data snapshot</h3>
-              </header>
-              <pre className="min-h-[200px] flex-1 overflow-y-auto rounded-xl border border-amber-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-amber-100">
-                {(() => {
-                  if (!isLoaded) return "Loading Clerk state...";
-                  if (!isSignedIn) return "Sign in to load Convex data.";
-                  if (messages === undefined) return "Loading Convex data...";
-                  if (messages.length === 0) return "No messages yet.";
-                  return JSON.stringify({ messageCount: messages.length, messages }, null, 2);
-                })()}
-              </pre>
+          <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-sky-200">Stripe</h2>
+              <p className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">Checkout sandbox</p>
+              <p className="text-sm text-neutral-400">Launch test checkout and capture debug events.</p>
             </div>
+            <BuyTicketButton priceId="price_1SCow4LGtZ8BdkwqLaowXCyE" onDebug={handleStripeDebug} />
+          </div>
 
-            <div className="flex flex-col gap-6 rounded-2xl border border-neutral-800/80 bg-neutral-900/40 p-6 shadow-inner shadow-black/20">
-              <div className="space-y-2">
-                <h2 className="font-semibold text-sky-200">Stripe checkout</h2>
-                <p className="text-xs uppercase tracking-widest text-neutral-500">Sandbox</p>
-                <p className="text-sm text-neutral-300">
-                  Launch Stripe checkout and capture debug events for local flows.
-                </p>
-              </div>
-              <BuyTicketButton priceId="price_1SCow4LGtZ8BdkwqLaowXCyE" onDebug={handleStripeDebug} />
-            </div>
-
-            <div className="flex flex-col gap-4 rounded-2xl border border-neutral-800/80 bg-neutral-900/30 p-6 shadow-inner shadow-black/20">
-              <header className="flex flex-col gap-1">
-                <span className="text-xs uppercase tracking-widest text-neutral-500">Stripe stream</span>
-                <h3 className="font-semibold text-sky-200">Console output</h3>
-              </header>
-              <pre className="min-h-[200px] flex-1 overflow-y-auto rounded-xl border border-sky-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-sky-100">
-                {stripeLogContent}
-              </pre>
-            </div>
-          </section>
-        </div>
+          <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">
+            <header className="space-y-1">
+              <p className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">Stripe stream</p>
+              <h3 className="text-lg font-semibold text-sky-200">Console output</h3>
+            </header>
+            <pre className="h-56 overflow-y-auto border border-sky-500/20 bg-neutral-950/80 p-4 text-xs leading-relaxed text-sky-100">
+              {stripeLogContent}
+            </pre>
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -44,7 +44,7 @@ export default function Home() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-950 py-12 text-neutral-100">
-      <div className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-10">
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-12">
         <div className="overflow-hidden rounded-3xl border border-neutral-800/80 bg-neutral-950/70 shadow-[0_40px_120px_-60px_rgba(15,15,15,0.8)]">
           <div className="flex flex-col gap-6 border-b border-neutral-800/80 bg-neutral-900/60 px-6 py-10 text-center sm:px-10">
             <p className="mx-auto w-fit rounded-full border border-fuchsia-500/40 bg-fuchsia-900/20 px-3 py-1 text-[10px] uppercase tracking-[0.35em] text-fuchsia-200/80">
@@ -58,123 +58,117 @@ export default function Home() {
             </div>
           </div>
 
-          <section className="space-y-12 px-6 py-10 sm:px-12">
-            <div className="grid gap-10 md:grid-cols-[1.05fr_1fr] md:items-start md:gap-12">
-              <div className="space-y-6">
-                <div className="space-y-2">
-                  <h2 className="font-semibold text-fuchsia-200">Authentication</h2>
-                  <p className="text-xs uppercase tracking-widest text-neutral-500">Clerk access</p>
-                  <p className="text-sm text-neutral-300">
-                    Sign in with Clerk to unlock the debugging utilities.
-                  </p>
-                </div>
-                <Unauthenticated>
-                  <SignInButton mode="modal">
-                    <button className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-fuchsia-500/40 bg-fuchsia-900/30 px-4 py-3 text-sm font-semibold text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-800/40">
-                      Sign in with Clerk
-                    </button>
-                  </SignInButton>
-                </Unauthenticated>
-                <Authenticated>
-                  <div className="grid gap-4 rounded-xl border border-fuchsia-500/20 bg-fuchsia-900/10 p-5">
-                    <div className="flex items-center justify-between gap-4">
-                      <span className="text-xs uppercase tracking-widest text-neutral-400">Current user</span>
-                      <UserButton userProfileMode="modal" />
-                    </div>
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <button
-                        className="inline-flex items-center justify-center rounded-lg border border-fuchsia-500/30 bg-fuchsia-800/40 px-4 py-2 text-sm font-medium text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-700/50"
-                        onClick={handleClerkTest}
-                      >
-                        Test Clerk
-                      </button>
-                      <button
-                        className="inline-flex items-center justify-center rounded-lg border border-emerald-500/30 bg-emerald-800/30 px-4 py-2 text-sm font-medium text-emerald-50 transition hover:border-emerald-300/60 hover:bg-emerald-700/40"
-                        onClick={handleAddDemoMessage}
-                      >
-                        Add demo message
-                      </button>
-                    </div>
+          <section className="grid gap-8 px-6 py-10 sm:px-12 lg:grid-cols-2 xl:gap-12">
+            <div className="flex flex-col gap-6 rounded-2xl border border-neutral-800/80 bg-neutral-900/40 p-6 shadow-inner shadow-black/20">
+              <div className="space-y-2">
+                <h2 className="font-semibold text-fuchsia-200">Authentication</h2>
+                <p className="text-xs uppercase tracking-widest text-neutral-500">Clerk access</p>
+                <p className="text-sm text-neutral-300">
+                  Sign in with Clerk to unlock the debugging utilities.
+                </p>
+              </div>
+              <Unauthenticated>
+                <SignInButton mode="modal">
+                  <button className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-fuchsia-500/40 bg-fuchsia-900/30 px-4 py-3 text-sm font-semibold text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-800/40">
+                    Sign in with Clerk
+                  </button>
+                </SignInButton>
+              </Unauthenticated>
+              <Authenticated>
+                <div className="grid gap-4 rounded-xl border border-fuchsia-500/20 bg-fuchsia-900/10 p-5">
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-xs uppercase tracking-widest text-neutral-400">Current user</span>
+                    <UserButton userProfileMode="modal" />
                   </div>
-                </Authenticated>
-              </div>
-
-              <div className="space-y-4 md:pl-4">
-                <header className="flex flex-col gap-1">
-                  <span className="text-xs uppercase tracking-widest text-neutral-500">Clerk stream</span>
-                  <h3 className="font-semibold text-fuchsia-200">State snapshot</h3>
-                </header>
-                <pre className="max-h-80 overflow-y-auto rounded-xl border border-fuchsia-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-fuchsia-100">
-                  {isLoaded
-                    ? JSON.stringify(
-                        {
-                          isSignedIn,
-                          userId: user?.id ?? null,
-                          email: user?.primaryEmailAddress?.emailAddress ?? null,
-                        },
-                        null,
-                        2,
-                      )
-                    : "Loading Clerk state..."}
-                </pre>
-              </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <button
+                      className="inline-flex items-center justify-center rounded-lg border border-fuchsia-500/30 bg-fuchsia-800/40 px-4 py-2 text-sm font-medium text-white transition hover:border-fuchsia-300/60 hover:bg-fuchsia-700/50"
+                      onClick={handleClerkTest}
+                    >
+                      Test Clerk
+                    </button>
+                    <button
+                      className="inline-flex items-center justify-center rounded-lg border border-emerald-500/30 bg-emerald-800/30 px-4 py-2 text-sm font-medium text-emerald-50 transition hover:border-emerald-300/60 hover:bg-emerald-700/40"
+                      onClick={handleAddDemoMessage}
+                    >
+                      Add demo message
+                    </button>
+                  </div>
+                </div>
+              </Authenticated>
             </div>
 
-            <div className="grid gap-10 md:grid-cols-[1.05fr_1fr] md:items-start md:gap-12">
-              <div className="space-y-6">
-                <div className="space-y-2">
-                  <h2 className="font-semibold text-amber-200">Convex actions</h2>
-                  <p className="text-xs uppercase tracking-widest text-neutral-500">Diagnostics</p>
-                  <p className="text-sm text-neutral-300">
-                    Trigger a Convex check to confirm connectivity and observe data flow.
-                  </p>
-                </div>
-                <button
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-amber-500/40 bg-amber-900/30 px-4 py-3 text-sm font-semibold text-amber-100 transition hover:border-amber-300/60 hover:bg-amber-800/40"
-                  onClick={handleConvexTest}
-                >
-                  Test Convex
-                </button>
-              </div>
-
-              <div className="space-y-4 md:pl-4">
-                <header className="flex flex-col gap-1">
-                  <span className="text-xs uppercase tracking-widest text-neutral-500">Convex stream</span>
-                  <h3 className="font-semibold text-amber-200">Data snapshot</h3>
-                </header>
-                <pre className="max-h-80 overflow-y-auto rounded-xl border border-amber-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-amber-100">
-                  {(() => {
-                    if (!isLoaded) return "Loading Clerk state...";
-                    if (!isSignedIn) return "Sign in to load Convex data.";
-                    if (messages === undefined) return "Loading Convex data...";
-                    if (messages.length === 0) return "No messages yet.";
-                    return JSON.stringify({ messageCount: messages.length, messages }, null, 2);
-                  })()}
-                </pre>
-              </div>
+            <div className="flex flex-col gap-4 rounded-2xl border border-neutral-800/80 bg-neutral-900/30 p-6 shadow-inner shadow-black/20">
+              <header className="flex flex-col gap-1">
+                <span className="text-xs uppercase tracking-widest text-neutral-500">Clerk stream</span>
+                <h3 className="font-semibold text-fuchsia-200">State snapshot</h3>
+              </header>
+              <pre className="min-h-[200px] flex-1 overflow-y-auto rounded-xl border border-fuchsia-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-fuchsia-100">
+                {isLoaded
+                  ? JSON.stringify(
+                      {
+                        isSignedIn,
+                        userId: user?.id ?? null,
+                        email: user?.primaryEmailAddress?.emailAddress ?? null,
+                      },
+                      null,
+                      2,
+                    )
+                  : "Loading Clerk state..."}
+              </pre>
             </div>
 
-            <div className="grid gap-10 md:grid-cols-[1.05fr_1fr] md:items-start md:gap-12">
-              <div className="space-y-6">
-                <div className="space-y-2">
-                  <h2 className="font-semibold text-sky-200">Stripe checkout</h2>
-                  <p className="text-xs uppercase tracking-widest text-neutral-500">Sandbox</p>
-                  <p className="text-sm text-neutral-300">
-                    Launch Stripe checkout and capture debug events for local flows.
-                  </p>
-                </div>
-                <BuyTicketButton priceId="price_1SCow4LGtZ8BdkwqLaowXCyE" onDebug={handleStripeDebug} />
+            <div className="flex flex-col gap-6 rounded-2xl border border-neutral-800/80 bg-neutral-900/40 p-6 shadow-inner shadow-black/20">
+              <div className="space-y-2">
+                <h2 className="font-semibold text-amber-200">Convex actions</h2>
+                <p className="text-xs uppercase tracking-widest text-neutral-500">Diagnostics</p>
+                <p className="text-sm text-neutral-300">
+                  Trigger a Convex check to confirm connectivity and observe data flow.
+                </p>
               </div>
+              <button
+                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-amber-500/40 bg-amber-900/30 px-4 py-3 text-sm font-semibold text-amber-100 transition hover:border-amber-300/60 hover:bg-amber-800/40"
+                onClick={handleConvexTest}
+              >
+                Test Convex
+              </button>
+            </div>
 
-              <div className="space-y-4 md:pl-4">
-                <header className="flex flex-col gap-1">
-                  <span className="text-xs uppercase tracking-widest text-neutral-500">Stripe stream</span>
-                  <h3 className="font-semibold text-sky-200">Console output</h3>
-                </header>
-                <pre className="max-h-80 overflow-y-auto rounded-xl border border-sky-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-sky-100">
-                  {stripeLogContent}
-                </pre>
+            <div className="flex flex-col gap-4 rounded-2xl border border-neutral-800/80 bg-neutral-900/30 p-6 shadow-inner shadow-black/20">
+              <header className="flex flex-col gap-1">
+                <span className="text-xs uppercase tracking-widest text-neutral-500">Convex stream</span>
+                <h3 className="font-semibold text-amber-200">Data snapshot</h3>
+              </header>
+              <pre className="min-h-[200px] flex-1 overflow-y-auto rounded-xl border border-amber-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-amber-100">
+                {(() => {
+                  if (!isLoaded) return "Loading Clerk state...";
+                  if (!isSignedIn) return "Sign in to load Convex data.";
+                  if (messages === undefined) return "Loading Convex data...";
+                  if (messages.length === 0) return "No messages yet.";
+                  return JSON.stringify({ messageCount: messages.length, messages }, null, 2);
+                })()}
+              </pre>
+            </div>
+
+            <div className="flex flex-col gap-6 rounded-2xl border border-neutral-800/80 bg-neutral-900/40 p-6 shadow-inner shadow-black/20">
+              <div className="space-y-2">
+                <h2 className="font-semibold text-sky-200">Stripe checkout</h2>
+                <p className="text-xs uppercase tracking-widest text-neutral-500">Sandbox</p>
+                <p className="text-sm text-neutral-300">
+                  Launch Stripe checkout and capture debug events for local flows.
+                </p>
               </div>
+              <BuyTicketButton priceId="price_1SCow4LGtZ8BdkwqLaowXCyE" onDebug={handleStripeDebug} />
+            </div>
+
+            <div className="flex flex-col gap-4 rounded-2xl border border-neutral-800/80 bg-neutral-900/30 p-6 shadow-inner shadow-black/20">
+              <header className="flex flex-col gap-1">
+                <span className="text-xs uppercase tracking-widest text-neutral-500">Stripe stream</span>
+                <h3 className="font-semibold text-sky-200">Console output</h3>
+              </header>
+              <pre className="min-h-[200px] flex-1 overflow-y-auto rounded-xl border border-sky-500/15 bg-neutral-950/80 p-4 text-xs leading-relaxed text-sky-100">
+                {stripeLogContent}
+              </pre>
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Summary
- reorganize the test dashboard cards into a consistent two-column grid so Clerk, Convex, and Stripe controls pair with their consoles
- widen the main container and refresh card styling to keep the existing aesthetic while filling more of the viewport

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dc292d24688326abf4a489fa40d3b9