### PR TITLE
Implement checkout.session.completed webhook ingestion

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -4,16 +4,37 @@ import Stripe from "stripe";
 
 export const runtime = "nodejs";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!); // set sk_test_... in env
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: process.env.STRIPE_API_VERSION as Stripe.LatestApiVersion | undefined,
+  maxNetworkRetries: 2,
+});
+
+type CheckoutRequest = {
+  priceId?: unknown;
+  quantity?: unknown;
+};
 
 export async function POST(req: NextRequest) {
-  const { priceId, quantity } = await req.json();
+  const body = (await req.json()) as CheckoutRequest;
+
+  if (typeof body.priceId !== "string" || !body.priceId) {
+    return NextResponse.json({ error: "priceId is required" }, { status: 400 });
+  }
+
+  const parsedQuantity =
+    typeof body.quantity === "number" && Number.isInteger(body.quantity) && body.quantity > 0
+      ? body.quantity
+      : 1;
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
-    line_items: [{ price: priceId, quantity }],
-    success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/test`,
-    cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/test`,
+    line_items: [{ price: body.priceId, quantity: parsedQuantity }],
+    client_reference_id: crypto.randomUUID(), // Attach a stable key so the webhook can link back to the client request.
+    metadata: { eventId: "demo-event-123" }, // Minimal metadata proves end-to-end flow and is easy to extend later.
+    success_url: `${siteUrl}/test`,
+    cancel_url: `${siteUrl}/test`,
   });
 
   return NextResponse.json({ url: session.url });

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -1,54 +1,75 @@
 // app/api/webhook/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import Stripe from "stripe";
+import { fetchMutation } from "convex/nextjs";
+import { internal } from "@/convex/_generated/api";
 
 export const runtime = "nodejs"; // required: webhooks can't run on Edge
 export const dynamic = "force-dynamic"; // avoid static optimization
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: process.env.STRIPE_API_VERSION as Stripe.LatestApiVersion | undefined,
+  maxNetworkRetries: 2,
+});
+
+function isCheckoutSession(object: unknown): object is Stripe.Checkout.Session {
+  return (
+    !!object &&
+    typeof object === "object" &&
+    (object as { object?: string }).object === "checkout.session"
+  );
+}
 
 export async function POST(req: NextRequest) {
-  // 1) Read raw body for signature verification
-  const rawBody = await req.text();
-  const sig = req.headers.get("stripe-signature");
-  if (!sig) return NextResponse.json({ error: "Missing signature" }, { status: 400 });
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.error("Missing STRIPE_WEBHOOK_SECRET for Stripe webhook verification");
+    return NextResponse.json({ error: "Misconfigured webhook" }, { status: 500 });
+  }
+
+  const signature = req.headers.get("stripe-signature");
+  if (!signature) {
+    return NextResponse.json({ error: "Missing signature" }, { status: 400 });
+  }
+
+  const rawBody = await req.text(); // Never parse/alter before verification.
 
   let event: Stripe.Event;
   try {
-    event = stripe.webhooks.constructEvent(
-      rawBody,
-      sig,
-      process.env.STRIPE_WEBHOOK_SECRET!
-    );
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : "Invalid signature";
-    return NextResponse.json({ error: msg }, { status: 400 });
+    event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid signature";
+    return NextResponse.json({ error: message }, { status: 400 });
   }
 
-  // 2) Handle events you care about
   try {
     switch (event.type) {
       case "checkout.session.completed": {
-        const session = event.data.object as Stripe.Checkout.Session;
-        // TODO: mint/activate ticket in Convex (idempotent on event.id)
-        // session.id, session.client_reference_id, session.metadata, etc.
-        break;
-      }
-      case "checkout.session.expired": {
-        const session = event.data.object as Stripe.Checkout.Session;
-        // TODO: mark any pending reservation as expired
+        const dataObject = event.data.object;
+        if (!isCheckoutSession(dataObject)) {
+          throw new Error("Unexpected object payload for checkout.session.completed");
+        }
+
+        await fetchMutation(internal.stripeEvents.ingest, {
+          eventId: event.id,
+          type: event.type,
+          created: event.created,
+          sessionId: dataObject.id,
+          clientReferenceId: dataObject.client_reference_id ?? undefined,
+          raw: JSON.stringify(dataObject),
+        });
+
         break;
       }
       default:
-        // ignore others
+        // Fast 2xx for events we do not handle yet keeps the delivery channel healthy.
         break;
     }
-  } catch (err) {
-    // Your handler threw—return 500 so Stripe can retry
-    const msg = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: msg }, { status: 500 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Failed to process Stripe webhook", { eventId: event.id, type: event.type, message });
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 
-  // 3) Acknowledge receipt
   return new NextResponse(null, { status: 200 });
 }

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -11,6 +11,7 @@ export default function Home() {
   const messages = useQuery(api.messages.getForCurrentUser, isSignedIn ? {} : "skip"); // added convex query guarded by auth. Wait for user to be authenicated, then call useQuery to get the messages for the current user.
   const addMessage = useMutation(api.messages.add);
   const [stripeLogs, setStripeLogs] = useState<BuyTicketButtonDebugEntry[]>([]);
+  const stripeEvents = useQuery(api.stripeEvents.listRecent, { limit: 10 });
 
   const handleAddDemoMessage = () => {
     addMessage({ body: "demo-" + Date.now() });
@@ -41,6 +42,22 @@ export default function Home() {
   const stripeLogContent = stripeLogs.length
     ? JSON.stringify(stripeLogs, null, 2)
     : "Use the Stripe checkout controls to populate debug logs.";
+
+  const stripeEventsContent = (() => {
+    if (stripeEvents === undefined) return "Loading webhook events...";
+    if (stripeEvents.length === 0) return "No webhook events ingested yet.";
+    return JSON.stringify(
+      stripeEvents.map(({ eventId, type, sessionId, clientReferenceId, created }) => ({
+        eventId,
+        type,
+        sessionId,
+        clientReferenceId: clientReferenceId ?? null,
+        created,
+      })),
+      null,
+      2,
+    );
+  })();
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-950 py-8 text-neutral-100">
@@ -154,6 +171,16 @@ export default function Home() {
               <p className="text-sm text-neutral-400">Launch test checkout and capture debug events.</p>
             </div>
             <BuyTicketButton priceId="price_1SCow4LGtZ8BdkwqLaowXCyE" onDebug={handleStripeDebug} />
+          </div>
+
+          <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">
+            <header className="space-y-1">
+              <p className="text-[11px] uppercase tracking-[0.28em] text-neutral-500">Stripe webhooks</p>
+              <h3 className="text-lg font-semibold text-sky-200">Last 10 ingested events</h3>
+            </header>
+            <pre className="h-56 overflow-y-auto border border-sky-500/20 bg-neutral-950/80 p-4 text-xs leading-relaxed text-sky-100">
+              {stripeEventsContent}
+            </pre>
           </div>
 
           <div className="flex flex-col gap-4 bg-neutral-950/70 p-6">

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as messages from "../messages.js";
+import type * as stripeEvents from "../stripeEvents.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -25,6 +26,7 @@ import type * as messages from "../messages.js";
  */
 declare const fullApi: ApiFromModules<{
   messages: typeof messages;
+  stripeEvents: typeof stripeEvents;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -62,16 +62,15 @@ export default defineSchema({
 
   // Stripe at-least-once safety net (dedupe + audit)
   stripeEvents: defineTable({
-    stripeEventId: v.string(),            // event.id
+    eventId: v.string(),                  // Stripe event.id (unique per delivery attempt)
     type: v.string(),                     // e.g., checkout.session.completed
-    created: v.number(),                  // Stripe's event.created (s)
-    firstSeenAt: v.number(),              // ms epoch
-    lastHandledAt: v.optional(v.number()),
-    handled: v.boolean(),
-    payloadHash: v.string(),              // hash(rawBody) for audit
-    sessionId: v.optional(v.string())     // extracted if present
+    created: v.number(),                  // Stripe's event.created (s epoch)
+    sessionId: v.string(),                // checkout.session id we fulfilled
+    clientReferenceId: v.optional(v.string()),
+    raw: v.string(),                      // raw JSON for audit + debugging
   })
-    .index("by_eventId", ["stripeEventId"])
+    .index("by_eventId", ["eventId"])
+    .index("by_created", ["created"])
     .index("by_sessionId", ["sessionId"]),
 
   // Atomic redemption trail (auditable, supports replays)

--- a/convex/stripeEvents.ts
+++ b/convex/stripeEvents.ts
@@ -1,0 +1,49 @@
+// convex/stripeEvents.ts
+import { internalMutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const listRecent = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, { limit }) => {
+    const take = limit ?? 10;
+    return await ctx.db
+      .query("stripeEvents")
+      .order("desc")
+      .take(take);
+  },
+});
+
+export const ingest = internalMutation({
+  args: {
+    eventId: v.string(),
+    type: v.string(),
+    created: v.number(),
+    sessionId: v.string(),
+    clientReferenceId: v.optional(v.string()),
+    raw: v.string(),
+  },
+  handler: async (
+    ctx,
+    { eventId, type, created, sessionId, clientReferenceId, raw }
+  ) => {
+    const existing = await ctx.db
+      .query("stripeEvents")
+      .withIndex("by_eventId", (q) => q.eq("eventId", eventId))
+      .first();
+
+    if (existing) {
+      return { inserted: false, id: existing._id };
+    }
+
+    const insertedId = await ctx.db.insert("stripeEvents", {
+      eventId,
+      type,
+      created,
+      sessionId,
+      clientReferenceId,
+      raw,
+    });
+
+    return { inserted: true, id: insertedId };
+  },
+});


### PR DESCRIPTION
## Summary
- validate checkout payloads and attach a client_reference_id when creating sessions
- verify checkout.session.completed webhooks and record events through an idempotent Convex mutation
- surface recent webhook ingest results on the /test debug page for manual verification

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e03aa931b88326805e305bda8dcd2f