### PR TITLE
Add payment success route with Convex ticket lookup

### DIFF
--- a/app/payment-succeeded/page.tsx
+++ b/app/payment-succeeded/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import TicketReceipt from "./ticket-receipt";
+
+export const metadata: Metadata = {
+  title: "Payment succeeded",
+  description:
+    "Review the ticket minted for this Stripe Checkout session and confirm webhook delivery.",
+};
+
+type PaymentSucceededPageProps = {
+  searchParams?:
+    | Record<string, string | string[] | undefined>
+    | Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function PaymentSucceededPage({ searchParams }: PaymentSucceededPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const sessionParam = resolvedSearchParams?.session_id;
+  const sessionId = Array.isArray(sessionParam) ? sessionParam[0] : sessionParam;
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-950 py-10 text-neutral-100">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 sm:px-6 lg:px-8">
+        <header className="flex flex-col gap-4 rounded-3xl border border-emerald-500/20 bg-emerald-950/40 p-6 text-sm text-emerald-100 shadow-[0_20px_45px_-40px_rgba(16,185,129,0.9)]">
+          <div className="flex flex-col gap-1 text-xs uppercase tracking-[0.32em] text-emerald-400/80 sm:flex-row sm:items-center sm:justify-between">
+            <span className="rounded-full border border-emerald-400/30 bg-emerald-950/50 px-3 py-1 text-[10px] font-semibold text-emerald-200">
+              Payment confirmed
+            </span>
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-900/40 px-3 py-1 text-[10px] font-semibold tracking-[0.24em] text-emerald-100 transition hover:border-emerald-200/60 hover:bg-emerald-900/60"
+            >
+              ← Back to control deck
+            </Link>
+          </div>
+          <div className="space-y-2 text-sm normal-case tracking-normal text-emerald-100">
+            <h1 className="text-2xl font-semibold text-white sm:text-3xl">Your ticket is almost ready</h1>
+            <p className="max-w-2xl text-sm text-emerald-100/80">
+              We redirect here after Stripe Checkout succeeds. Once the webhook finishes minting the ticket, it will appear below
+              along with the purchase details fetched from Convex.
+            </p>
+          </div>
+        </header>
+
+        <section className="rounded-3xl border border-neutral-800/60 bg-neutral-950/70 p-6 shadow-[0_20px_50px_-48px_rgba(59,130,246,0.6)]">
+          <TicketReceipt sessionId={sessionId} />
+        </section>
+
+        <footer className="rounded-3xl border border-neutral-800/50 bg-neutral-950/70 p-5 text-xs text-neutral-400">
+          <div className="space-y-2">
+            <p className="font-semibold uppercase tracking-[0.28em] text-neutral-500">Next steps</p>
+            <p>
+              Connect your local Stripe CLI webhook forwarder so successful checkout events populate Convex. The official Stripe
+              guide on
+              <a
+                href="https://stripe.com/docs/payments/checkout/fulfill-orders"
+                target="_blank"
+                rel="noreferrer"
+                className="ml-1 text-emerald-300 underline decoration-dotted underline-offset-4 hover:text-emerald-200"
+              >
+                fulfilling orders with Checkout
+              </a>
+              {" "}
+              covers the flow we expect.
+            </p>
+          </div>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/app/payment-succeeded/ticket-receipt.tsx
+++ b/app/payment-succeeded/ticket-receipt.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo } from "react";
+import { Unauthenticated, useQuery } from "convex/react";
+import { SignInButton } from "@clerk/nextjs";
+import Link from "next/link";
+import { api } from "@/convex/_generated/api";
+import { AlertCircle, CheckCircle2, Clock3, Loader2, ShieldAlert, Ticket as TicketIcon } from "lucide-react";
+
+type TicketReceiptProps = {
+  sessionId?: string;
+};
+
+type TicketQueryResult =
+  | { status: "unauthenticated" }
+  | { status: "not_found" }
+  | { status: "forbidden" }
+  | {
+      status: "pending";
+      purchase: {
+        createdAt: number;
+        paymentStatus: string;
+        amountTotal: number;
+        currency: string;
+      };
+    }
+  | {
+      status: "ready";
+      ticket: {
+        ticketId: string;
+        eventId: string;
+        status: string;
+        issuedAt: number;
+        validFrom: number | null;
+        validTo: number | null;
+      };
+      purchase: {
+        createdAt: number;
+        paymentStatus: string;
+        amountTotal: number;
+        currency: string;
+      };
+    };
+
+const formatCurrency = (amountCents: number, currency: string) => {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currency.toUpperCase(),
+    }).format(amountCents / 100);
+  } catch {
+    return `${(amountCents / 100).toFixed(2)} ${currency}`;
+  }
+};
+
+const formatTimestamp = (ms: number) =>
+  new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(ms));
+
+export default function TicketReceipt({ sessionId }: TicketReceiptProps) {
+  const result = useQuery(api.tickets.getByStripeSession, sessionId ? { sessionId } : "skip");
+  const typedResult = result as TicketQueryResult | undefined;
+  const validityWindows = useMemo(() => {
+    if (!typedResult || typedResult.status !== "ready") return [];
+    const windows: string[] = [];
+    if (typedResult.ticket.validFrom) {
+      windows.push(`Valid from ${formatTimestamp(typedResult.ticket.validFrom)}`);
+    }
+    if (typedResult.ticket.validTo) {
+      windows.push(`Valid until ${formatTimestamp(typedResult.ticket.validTo)}`);
+    }
+    return windows;
+  }, [typedResult]);
+
+  if (!sessionId) {
+    return (
+      <div className="grid gap-4 text-sm text-neutral-300">
+        <div className="flex items-center gap-3 rounded-2xl border border-amber-400/40 bg-amber-900/20 p-4 text-amber-100">
+          <AlertCircle className="h-5 w-5 shrink-0" />
+          <div>
+            <p className="font-semibold uppercase tracking-[0.28em] text-amber-200">Missing session reference</p>
+            <p className="text-amber-100/80">
+              Stripe should append a <code className="rounded bg-neutral-900 px-1 py-0.5 text-xs text-amber-200">session_id</code> query
+              parameter to the success URL. Confirm your <code className="rounded bg-neutral-900 px-1 py-0.5 text-xs text-amber-200">success_url</code>
+              includes <code className="rounded bg-neutral-900 px-1 py-0.5 text-xs text-amber-200">?session_id={"{CHECKOUT_SESSION_ID}"}</code>.
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/"
+          className="inline-flex max-w-fit items-center gap-2 rounded-full border border-neutral-700/70 bg-neutral-900/60 px-4 py-2 text-xs uppercase tracking-[0.28em] text-neutral-200 transition hover:border-neutral-500/70 hover:bg-neutral-900"
+        >
+          Return home
+        </Link>
+      </div>
+    );
+  }
+
+  if (result === undefined) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-sky-400/30 bg-sky-900/20 p-6 text-sky-100">
+        <Loader2 className="h-6 w-6 animate-spin" aria-hidden />
+        <p className="text-sm">Checking Convex for the ticket minted from this session…</p>
+      </div>
+    );
+  }
+
+  if (!typedResult) {
+    return null;
+  }
+
+  if (typedResult.status === "unauthenticated") {
+    return (
+      <Unauthenticated>
+        <div className="grid gap-4 rounded-2xl border border-neutral-700/60 bg-neutral-900/60 p-6 text-neutral-200">
+          <p className="text-sm">
+            Sign in with the same account that completed checkout to reveal the ticket minted for this session.
+          </p>
+          <SignInButton mode="modal">
+            <button className="inline-flex items-center justify-center gap-2 rounded-lg border border-sky-400/40 bg-sky-900/40 px-4 py-2 text-sm font-semibold text-white transition hover:border-sky-200/60 hover:bg-sky-900/60">
+              Sign in to continue
+            </button>
+          </SignInButton>
+        </div>
+      </Unauthenticated>
+    );
+  }
+
+  if (typedResult.status === "forbidden") {
+    return (
+      <div className="flex items-start gap-3 rounded-2xl border border-rose-500/40 bg-rose-950/40 p-5 text-sm text-rose-100">
+        <ShieldAlert className="h-6 w-6 shrink-0" />
+        <div className="space-y-2">
+          <p className="text-base font-semibold text-white">Access denied</p>
+          <p className="text-rose-100/80">
+            This checkout session belongs to a different signed-in user. Sign in with the correct account or launch a new checkout
+            from the kiosk dashboard.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (typedResult.status === "not_found") {
+    return (
+      <div className="grid gap-3 rounded-2xl border border-neutral-700/60 bg-neutral-900/60 p-6 text-neutral-300">
+        <div className="flex items-center gap-3 text-sm">
+          <AlertCircle className="h-5 w-5 text-neutral-400" />
+          <p>
+            We could not find a purchase linked to this session yet. Give the webhook a moment to arrive, then refresh this page.
+          </p>
+        </div>
+        <p className="text-xs uppercase tracking-[0.24em] text-neutral-500">
+          Tip: verify your webhook listener is forwarding <code className="rounded bg-neutral-950 px-1 py-0.5 text-[10px]">checkout.session.completed</code>
+          events to Convex.
+        </p>
+      </div>
+    );
+  }
+
+  const purchaseSummary = (
+    <div className="grid gap-1 rounded-2xl border border-neutral-700/40 bg-neutral-900/40 p-4 text-xs uppercase tracking-[0.24em] text-neutral-400">
+      <span className="text-neutral-200">Purchase summary</span>
+      <div className="grid gap-1 text-[11px] normal-case tracking-normal text-neutral-300">
+        <span>
+          Amount:&nbsp;
+          <strong className="text-neutral-100">
+            {formatCurrency(typedResult.purchase.amountTotal, typedResult.purchase.currency)}
+          </strong>
+        </span>
+        <span>
+          Status:&nbsp;
+          <strong className="text-neutral-100">{typedResult.purchase.paymentStatus}</strong>
+        </span>
+        <span>
+          Created:&nbsp;
+          <strong className="text-neutral-100">{formatTimestamp(typedResult.purchase.createdAt)}</strong>
+        </span>
+      </div>
+    </div>
+  );
+
+  if (typedResult.status === "pending") {
+    return (
+      <div className="grid gap-4">
+        <div className="flex items-start gap-3 rounded-2xl border border-amber-400/40 bg-amber-900/30 p-5 text-sm text-amber-100">
+          <Clock3 className="h-6 w-6 shrink-0" />
+          <div className="space-y-2">
+            <p className="text-base font-semibold text-white">Waiting for ticket minting</p>
+            <p className="text-amber-100/80">
+              The purchase has been recorded but the ticket document has not been generated yet. Once your webhook handler writes to
+              the <code className="rounded bg-neutral-900 px-1 py-0.5 text-xs text-amber-200">tickets</code> table, it will appear here automatically.
+            </p>
+          </div>
+        </div>
+        {purchaseSummary}
+      </div>
+    );
+  }
+
+  if (typedResult.status === "ready") {
+    return (
+      <div className="grid gap-5">
+        <div className="grid gap-4 rounded-3xl border border-emerald-500/40 bg-emerald-950/30 p-6 text-emerald-100">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.32em] text-emerald-300/80">Ticket ready</p>
+              <h2 className="text-2xl font-semibold text-white">Session minted ticket</h2>
+            </div>
+            <CheckCircle2 className="h-6 w-6 text-emerald-300" aria-hidden />
+          </div>
+          <div className="grid gap-3 rounded-2xl border border-emerald-400/30 bg-emerald-900/30 p-5 text-sm text-emerald-50">
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full border border-emerald-300/40 bg-emerald-900/40">
+                <TicketIcon className="h-6 w-6" aria-hidden />
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-[0.28em] text-emerald-200">Ticket id</p>
+                <p className="font-mono text-lg text-white">{typedResult.ticket.ticketId}</p>
+              </div>
+            </div>
+            <dl className="grid gap-3 text-xs uppercase tracking-[0.28em] text-emerald-200">
+              <div className="flex flex-col gap-1 rounded-xl border border-emerald-400/20 bg-emerald-900/40 p-4 text-[11px] text-emerald-100">
+                <dt>Event reference</dt>
+                <dd className="font-mono text-base tracking-normal text-white">{typedResult.ticket.eventId}</dd>
+              </div>
+              <div className="flex flex-col gap-1 rounded-xl border border-emerald-400/20 bg-emerald-900/40 p-4 text-[11px] text-emerald-100">
+                <dt>Status</dt>
+                <dd className="text-base tracking-normal text-white">{typedResult.ticket.status}</dd>
+              </div>
+              <div className="flex flex-col gap-1 rounded-xl border border-emerald-400/20 bg-emerald-900/40 p-4 text-[11px] text-emerald-100">
+                <dt>Issued</dt>
+                <dd className="text-base tracking-normal text-white">{formatTimestamp(typedResult.ticket.issuedAt)}</dd>
+              </div>
+              {validityWindows.map((window) => (
+                <div
+                  key={window}
+                  className="flex flex-col gap-1 rounded-xl border border-emerald-400/20 bg-emerald-900/40 p-4 text-[11px] text-emerald-100"
+                >
+                  <dt>Validity</dt>
+                  <dd className="text-base tracking-normal text-white">{window}</dd>
+                </div>
+              ))}
+            </dl>
+            <div className="rounded-xl border border-emerald-400/20 bg-emerald-900/40 p-4 text-xs text-emerald-100/80">
+              <p className="uppercase tracking-[0.24em] text-emerald-200">Implementation note</p>
+              <p className="mt-2 text-sm normal-case tracking-normal">
+                Swap this block with your production ticket component (QR code, barcode, etc.). The Convex query already provides the
+                identifiers you need to render it securely on the client.
+              </p>
+            </div>
+          </div>
+        </div>
+        {purchaseSummary}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type {
 } from "convex/server";
 import type * as messages from "../messages.js";
 import type * as stripeEvents from "../stripeEvents.js";
+import type * as tickets from "../tickets.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -27,6 +28,7 @@ import type * as stripeEvents from "../stripeEvents.js";
 declare const fullApi: ApiFromModules<{
   messages: typeof messages;
   stripeEvents: typeof stripeEvents;
+  tickets: typeof tickets;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/tickets.ts
+++ b/convex/tickets.ts
@@ -1,0 +1,65 @@
+// convex/tickets.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const getByStripeSession = query({
+  args: { sessionId: v.string() },
+  handler: async (ctx, { sessionId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return { status: "unauthenticated" as const };
+    }
+
+    const purchase = await ctx.db
+      .query("purchases")
+      .withIndex("by_session", (q) => q.eq("stripeSessionId", sessionId))
+      .first();
+
+    if (!purchase) {
+      return { status: "not_found" as const };
+    }
+
+    if (purchase.tokenIdentifier !== identity.tokenIdentifier) {
+      return { status: "forbidden" as const };
+    }
+
+    const ticket = await ctx.db
+      .query("tickets")
+      .withIndex("by_session", (q) => q.eq("stripeSessionId", sessionId))
+      .first();
+
+    if (!ticket) {
+      return {
+        status: "pending" as const,
+        purchase: {
+          createdAt: purchase.createdAt,
+          paymentStatus: purchase.paymentStatus,
+          amountTotal: purchase.amountTotal,
+          currency: purchase.currency,
+        },
+      };
+    }
+
+    if (ticket.ownerTokenIdentifier !== identity.tokenIdentifier) {
+      return { status: "forbidden" as const };
+    }
+
+    return {
+      status: "ready" as const,
+      ticket: {
+        ticketId: ticket.ticketId,
+        eventId: ticket.eventId,
+        status: ticket.status,
+        issuedAt: ticket.issuedAt,
+        validFrom: ticket.validFrom ?? null,
+        validTo: ticket.validTo ?? null,
+      },
+      purchase: {
+        createdAt: purchase.createdAt,
+        paymentStatus: purchase.paymentStatus,
+        amountTotal: purchase.amountTotal,
+        currency: purchase.currency,
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Summary
- add a payment-succeeded route that receives the Checkout session id and renders a guided success layout
- create a Convex query for retrieving tickets by Stripe session, covering pending, forbidden, and ready states
- surface purchase and ticket placeholders so the page is ready to wire up to minted ticket assets

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e41cdefd9083268ab87e6a142abc44